### PR TITLE
add game expiration and start delay to game component

### DIFF
--- a/contracts/dojo_dev.toml
+++ b/contracts/dojo_dev.toml
@@ -39,7 +39,7 @@ private_key = "0xc5b2fcab997346f3ea1c00b002ecf6f382c5f9c9659a3894eb783c5320f912"
 "tournaments-Game" = ["tournaments-game_mock"]
 "tournaments-GameCount" = ["tournaments-game_mock"]
 "tournaments-Settings" = ["tournaments-game_mock"]
-"tournaments-GameSettings" = ["tournaments-game_mock"]
+"tournaments-GameMetadata" = ["tournaments-game_mock"]
 "tournaments-SettingsCount" = ["tournaments-game_mock"]
 
 [migration]

--- a/contracts/src/components/interfaces.cairo
+++ b/contracts/src/components/interfaces.cairo
@@ -1,7 +1,7 @@
 use starknet::ContractAddress;
 use dojo::world::{WorldStorage, WorldStorageTrait, IWorldDispatcher};
 
-use tournaments::components::models::game::SettingsDetails;
+use tournaments::components::models::game::{SettingsDetails, TokenMetadata};
 
 use tournaments::components::libs::utils::ZERO;
 
@@ -11,11 +11,19 @@ pub const IGAME_METADATA_ID: felt252 =
 
 #[starknet::interface]
 pub trait IGame<TState> {
-    fn new_game(ref self: TState, settings_id: u32, to: ContractAddress) -> u64;
+    fn new_game(
+        ref self: TState,
+        player_name: felt252,
+        settings_id: u32,
+        available_at: u64,
+        expires_at: u64,
+        to: ContractAddress,
+    ) -> u64;
     fn get_score(self: @TState, token_id: u64) -> u64;
     fn get_settings_id(self: @TState, token_id: u64) -> u32;
     fn get_settings_details(self: @TState, settings_id: u32) -> SettingsDetails;
     fn settings_exists(self: @TState, settings_id: u32) -> bool;
+    fn token_metadata(self: @TState, token_id: u64) -> TokenMetadata;
 }
 
 #[generate_trait]

--- a/contracts/src/components/libs/game_store.cairo
+++ b/contracts/src/components/libs/game_store.cairo
@@ -3,7 +3,7 @@ use dojo::world::{WorldStorage};
 use dojo::model::{ModelStorage};
 
 use tournaments::components::models::game::{
-    GameMetadata, SettingsDetails, GameSettings, GameCount, Score,
+    GameMetadata, SettingsDetails, TokenMetadata, GameCount, Score,
 };
 
 use tournaments::components::game::game_component::{VERSION};
@@ -43,7 +43,7 @@ pub impl StoreImpl of StoreTrait {
     }
 
     #[inline(always)]
-    fn get_game_settings(self: Store, token_id: u64) -> GameSettings {
+    fn get_token_metadata(self: Store, token_id: u64) -> TokenMetadata {
         (self.world.read_model(token_id))
     }
 
@@ -81,7 +81,7 @@ pub impl StoreImpl of StoreTrait {
     }
 
     #[inline(always)]
-    fn set_game_settings(ref self: Store, model: @GameSettings) {
+    fn set_token_metadata(ref self: Store, model: @TokenMetadata) {
         self.world.write_model(model);
     }
 

--- a/contracts/src/components/libs/store.cairo
+++ b/contracts/src/components/libs/store.cairo
@@ -3,7 +3,7 @@ use dojo::world::{WorldStorage};
 use dojo::model::{ModelStorage};
 
 use tournaments::components::models::tournament::{
-    Tournament, EntryCount, Prize, TournamentScores, Token, TokenMetadata, TournamentConfig,
+    Tournament, EntryCount, Prize, TournamentScores, Token, Registration, TournamentConfig,
     TournamentTokenMetrics, PlatformMetrics, PrizeMetrics,
 };
 
@@ -53,7 +53,7 @@ pub impl StoreImpl of StoreTrait {
     }
 
     #[inline(always)]
-    fn get_token_metadata(self: Store, token_id: u64) -> TokenMetadata {
+    fn get_registration(self: Store, token_id: u64) -> Registration {
         (self.world.read_model(token_id))
     }
 
@@ -102,7 +102,7 @@ pub impl StoreImpl of StoreTrait {
     }
 
     #[inline(always)]
-    fn set_token_metadata(ref self: Store, model: @TokenMetadata) {
+    fn set_registration(ref self: Store, model: @Registration) {
         self.world.write_model(model);
     }
 

--- a/contracts/src/components/models/game.cairo
+++ b/contracts/src/components/models/game.cairo
@@ -8,7 +8,7 @@ use starknet::ContractAddress;
 #[derive(Drop, Serde)]
 pub struct GameMetadata {
     #[key]
-    pub game_address: ContractAddress,
+    pub address: ContractAddress,
     pub name: felt252,
     pub description: ByteArray,
     pub developer: felt252,
@@ -37,10 +37,15 @@ pub struct SettingsDetails {
 
 #[dojo::model]
 #[derive(Copy, Drop, Serde, IntrospectPacked)]
-pub struct GameSettings {
+pub struct TokenMetadata {
     #[key]
-    pub game_token_id: u64,
+    pub token_id: u64,
+    pub minted_by: ContractAddress,
+    pub player_name: felt252,
     pub settings_id: u32,
+    pub minted_at: u64,
+    pub available_at: u64,
+    pub expires_at: u64,
 }
 
 #[dojo::model]

--- a/contracts/src/components/models/tournament.cairo
+++ b/contracts/src/components/models/tournament.cairo
@@ -40,18 +40,10 @@ pub enum TokenDataType {
 
 #[derive(Copy, Drop, Serde, PartialEq, Introspect)]
 pub enum TournamentState {
-    PreRegistration,
     Registration,
-    Active,
+    Live,
+    Submission,
     Finalized,
-    ScoreSubmitted,
-}
-
-#[derive(Copy, Drop, Serde, PartialEq, Introspect)]
-pub enum GameState {
-    Registered,
-    Started,
-    ScoreSubmitted,
 }
 
 ///
@@ -80,14 +72,13 @@ pub struct Tournament {
 }
 
 #[dojo::model]
-#[derive(Copy, Drop, Serde)]
-pub struct TokenMetadata {
+#[derive(Copy, Drop, Serde, IntrospectPacked)]
+pub struct Registration {
     #[key]
-    pub token_id: u64,
-    pub tournament_id: u64,
     pub game_token_id: u64,
+    pub tournament_id: u64,
     pub entry_number: u32,
-    pub state: Option<GameState>,
+    pub submitted_score: bool,
 }
 
 #[dojo::model]

--- a/contracts/src/components/tests/interfaces.cairo
+++ b/contracts/src/components/tests/interfaces.cairo
@@ -1,7 +1,7 @@
 use tournaments::components::models::tournament::{
-    Tournament as TournamentModel, Premium, TokenDataType, GatedType, TokenMetadata,
+    Tournament as TournamentModel, Premium, TokenDataType, GatedType, Registration,
 };
-use tournaments::components::models::game::SettingsDetails;
+use tournaments::components::models::game::{SettingsDetails, TokenMetadata};
 
 use starknet::ContractAddress;
 use dojo::world::{WorldStorage, WorldStorageTrait, IWorldDispatcher};
@@ -142,7 +142,7 @@ pub trait ITournamentMock<TState> {
     // ITournament
     fn total_tournaments(self: @TState) -> u64;
     fn tournament(self: @TState, tournament_id: u64) -> TournamentModel;
-    fn tournament_token(self: @TState, token_id: u64) -> TokenMetadata;
+    fn get_registration(self: @TState, token_id: u64) -> Registration;
     fn tournament_entries(self: @TState, tournament_id: u64) -> u64;
     fn is_token_registered(self: @TState, token: ContractAddress) -> bool;
     // TODO: add for V2 (only ERC721 tokens)
@@ -163,11 +163,14 @@ pub trait ITournamentMock<TState> {
         settings_id: u32,
     ) -> (u64, u64);
     fn enter_tournament(
-        ref self: TState, tournament_id: u64, qualifying_token_id: Option<u256>,
-    ) -> (u64, TokenMetadata);
+        ref self: TState,
+        tournament_id: u64,
+        name: felt252,
+        player_address: ContractAddress,
+        qualifying_token_id: Option<u256>,
+    ) -> (u64, u32);
     fn start_game(ref self: TState, tournament_token_id: u64);
     fn submit_scores(ref self: TState, tournament_id: u64, token_ids: Array<u64>);
-    fn finalize_tournament(ref self: TState, tournament_id: u64);
     fn distribute_prize(ref self: TState, prize_id: u64);
     fn distribute_unclaimable_prize(ref self: TState, prize_id: u64);
     fn add_prize(
@@ -235,10 +238,19 @@ pub trait IGameMock<TState> {
     fn tokenURI(self: @TState, tokenId: u256) -> ByteArray;
 
     // IGame
+    fn new_game(
+        ref self: TState,
+        name: felt252,
+        settings_id: u32,
+        available_at: u64,
+        expires_at: u64,
+        to: ContractAddress,
+    ) -> u64;
     fn get_settings_id(self: @TState, game_id: u64) -> u32;
     fn get_settings_details(self: @TState, settings_id: u32) -> SettingsDetails;
     fn settings_exists(self: @TState, settings_id: u32) -> bool;
-    fn new_game(ref self: TState, settings_id: u32, to: ContractAddress) -> u64;
+    fn token_metadata(self: @TState, token_id: u64) -> TokenMetadata;
+
     // GameMock
     fn start_game(ref self: TState, game_id: u64);
     fn end_game(ref self: TState, game_id: u64, score: u64);

--- a/contracts/src/components/tests/libs/store.cairo
+++ b/contracts/src/components/tests/libs/store.cairo
@@ -3,7 +3,7 @@ use dojo::world::{WorldStorage};
 use dojo::model::{ModelStorage};
 
 use tournaments::components::models::tournament::{
-    Tournament, EntryCount, Prize, TournamentScores, Token, TokenMetadata, TournamentConfig,
+    Tournament, EntryCount, Prize, TournamentScores, Token, Registration, TournamentConfig,
     PlatformMetrics, PrizeMetrics, TournamentTokenMetrics,
 };
 
@@ -53,7 +53,7 @@ pub impl StoreImpl of StoreTrait {
     }
 
     #[inline(always)]
-    fn get_token_metadata(self: Store, token_id: u128) -> TokenMetadata {
+    fn get_registration(self: Store, token_id: u128) -> Registration {
         (self.world.read_model(token_id))
     }
 
@@ -99,7 +99,7 @@ pub impl StoreImpl of StoreTrait {
     }
 
     #[inline(always)]
-    fn set_token_metadata(ref self: Store, model: @TokenMetadata) {
+    fn set_registration(ref self: Store, model: @Registration) {
         self.world.write_model(model);
     }
 

--- a/contracts/src/components/tests/mocks/tournament_mock.cairo
+++ b/contracts/src/components/tests/mocks/tournament_mock.cairo
@@ -1,7 +1,7 @@
 use starknet::ContractAddress;
 use dojo::world::IWorldDispatcher;
 use tournaments::components::models::tournament::{
-    Tournament as TournamentModel, Premium, TokenDataType, GatedType, TokenMetadata,
+    Tournament as TournamentModel, Premium, TokenDataType, GatedType, Registration,
 };
 
 #[starknet::interface]
@@ -30,7 +30,7 @@ pub trait ITournamentMock<TState> {
     // ITournament
     fn total_tournaments(self: @TState) -> u64;
     fn tournament(self: @TState, tournament_id: u64) -> TournamentModel;
-    fn tournament_token(self: @TState, token_id: u64) -> TokenMetadata;
+    fn get_registration(self: @TState, token_id: u64) -> Registration;
     fn tournament_entries(self: @TState, tournament_id: u64) -> u64;
     fn is_token_registered(self: @TState, token: ContractAddress) -> bool;
     // TODO: add for V2 (only ERC721 tokens)
@@ -51,11 +51,14 @@ pub trait ITournamentMock<TState> {
         settings_id: u32,
     ) -> u64;
     fn enter_tournament(
-        ref self: TState, tournament_id: u64, qualifying_token_id: Option<u64>,
-    ) -> (u64, TokenMetadata);
+        ref self: TState,
+        tournament_id: u64,
+        name: felt252,
+        player_address: ContractAddress,
+        qualifying_token_id: Option<u64>,
+    ) -> (u64, u32);
     fn start_game(ref self: TState, tournament_token_id: u64);
     fn submit_scores(ref self: TState, tournament_id: u64, token_ids: Array<u64>);
-    fn finalize_tournament(ref self: TState, tournament_id: u64);
     fn distribute_prize(ref self: TState, prize_id: u64);
     fn distribute_unclaimable_prize(ref self: TState, prize_id: u64);
     fn add_prize(

--- a/contracts/src/presets/tournament.cairo
+++ b/contracts/src/presets/tournament.cairo
@@ -1,7 +1,7 @@
 use starknet::ContractAddress;
 use dojo::world::IWorldDispatcher;
 use tournaments::components::models::tournament::{
-    Tournament as TournamentModel, Premium, TokenDataType, GatedType, TokenMetadata,
+    Tournament as TournamentModel, Premium, TokenDataType, GatedType,
 };
 
 #[starknet::interface]
@@ -32,11 +32,14 @@ pub trait ITournament<TState> {
         settings_id: u32,
     ) -> u64;
     fn enter_tournament(
-        ref self: TState, tournament_id: u64, qualifying_token_id: Option<u256>,
-    ) -> (u64, TokenMetadata);
+        ref self: TState,
+        tournament_id: u64,
+        name: felt252,
+        player_address: ContractAddress,
+        qualifying_token_id: Option<u256>,
+    ) -> (u64, u32);
     fn start_game(ref self: TState, tournament_id: u64, tournament_token_id: u64);
     fn submit_scores(ref self: TState, tournament_id: u64, token_ids: Array<u64>);
-    fn finalize_tournament(ref self: TState, tournament_id: u64);
     fn claim_prizes(ref self: TState, tournament_id: u64, prize_ids: Array<u64>);
     fn claim_unclaimed_prizes(ref self: TState, tournament_id: u64, prize_ids: Array<u64>);
     fn add_prize(


### PR DESCRIPTION
- greatly simplifies tournament contract by enabling games to be minted as part of tournament entry
- this removes the need for a separate start_game endpoint as tournament can mint and distribute games as part of entering tournament/payment
- game component handles start delay and expiration, preventing game from being played outside tournament