### PR TITLE
Simplifies and improves tournament gating system

### DIFF
--- a/contracts/src/components/libs/store.cairo
+++ b/contracts/src/components/libs/store.cairo
@@ -5,7 +5,7 @@ use dojo::model::{ModelStorage};
 use tournaments::components::models::tournament::{
     Tournament, EntryCount, Prize, Leaderboard, Token, Registration, TournamentConfig,
     TournamentTokenMetrics, PlatformMetrics, PrizeMetrics, PrizeClaim, PrizeType, Metadata,
-    Schedule, GameConfig, EntryConfig,
+    Schedule, GameConfig, EntryFee, EntryRequirement,
 };
 
 use tournaments::components::constants::{VERSION};
@@ -96,11 +96,14 @@ pub impl StoreImpl of StoreTrait {
         metadata: Metadata,
         schedule: Schedule,
         game_config: GameConfig,
-        entry_config: Option<EntryConfig>,
+        entry_fee: Option<EntryFee>,
+        entry_requirement: Option<EntryRequirement>,
     ) -> Tournament {
         let id = self.increment_and_get_tournament_count();
         let creator = starknet::get_caller_address();
-        let tournament = Tournament { id, creator, metadata, schedule, game_config, entry_config };
+        let tournament = Tournament {
+            id, creator, metadata, schedule, game_config, entry_fee, entry_requirement,
+        };
         self.world.write_model(@tournament);
         tournament
     }

--- a/contracts/src/components/models/tournament.cairo
+++ b/contracts/src/components/models/tournament.cairo
@@ -11,7 +11,8 @@ pub struct Tournament {
     pub metadata: Metadata,
     pub schedule: Schedule,
     pub game_config: GameConfig,
-    pub entry_config: Option<EntryConfig>,
+    pub entry_fee: Option<EntryFee>,
+    pub entry_requirement: Option<EntryRequirement>,
 }
 
 #[derive(Drop, Serde, Introspect)]
@@ -38,12 +39,6 @@ pub struct GameConfig {
     pub address: ContractAddress,
     pub settings_id: u32,
     pub prize_spots: u8,
-}
-
-#[derive(Copy, Drop, Serde, PartialEq, Introspect)]
-pub struct EntryConfig {
-    pub fee: Option<EntryFee>,
-    pub requirement: Option<EntryRequirement>,
 }
 
 #[derive(Copy, Drop, Serde, PartialEq, Introspect)]
@@ -199,4 +194,24 @@ pub enum Role {
 pub enum PrizeType {
     EntryFees: Role,
     Sponsored: u64,
+}
+
+#[derive(Copy, Drop, Serde, PartialEq)]
+pub enum QualificationProof {
+    // For qualifying via previous tournament
+    Tournament: TournamentQualification,
+    // For qualifying via NFT ownership
+    NFT: NFTQualification,
+}
+
+#[derive(Copy, Drop, Serde, PartialEq)]
+pub struct TournamentQualification {
+    pub tournament_id: u64,
+    pub token_id: u64,
+    pub position: u8 // 1-based position in leaderboard
+}
+
+#[derive(Copy, Drop, Serde, PartialEq)]
+pub struct NFTQualification {
+    pub token_id: u256,
 }

--- a/contracts/src/components/tests/helpers.cairo
+++ b/contracts/src/components/tests/helpers.cairo
@@ -113,7 +113,9 @@ pub fn create_basic_tournament(
     tournament: ITournamentMockDispatcher, game: ContractAddress,
 ) -> (Tournament, u64) {
     tournament
-        .create_tournament(test_metadata(), test_schedule(), test_game_config(game), Option::None)
+        .create_tournament(
+            test_metadata(), test_schedule(), test_game_config(game), Option::None, Option::None,
+        )
 }
 
 pub fn create_settings_details(game: IGameMockDispatcher) {

--- a/contracts/src/components/tests/interfaces.cairo
+++ b/contracts/src/components/tests/interfaces.cairo
@@ -1,6 +1,6 @@
 use tournaments::components::models::tournament::{
     Tournament as TournamentModel, TokenType, Registration, PrizeType, TournamentState, Metadata,
-    Schedule, GameConfig, EntryConfig,
+    Schedule, GameConfig, EntryFee, EntryRequirement, QualificationProof,
 };
 use tournaments::components::models::game::{SettingsDetails, TokenMetadata};
 
@@ -155,14 +155,15 @@ pub trait ITournamentMock<TState> {
         metadata: Metadata,
         schedule: Schedule,
         game_config: GameConfig,
-        entry_config: Option<EntryConfig>,
+        entry_fee: Option<EntryFee>,
+        entry_requirement: Option<EntryRequirement>,
     ) -> (TournamentModel, u64);
     fn enter_tournament(
         ref self: TState,
         tournament_id: u64,
         player_name: felt252,
         player_address: ContractAddress,
-        qualifying_token_id: Option<u256>,
+        qualification: Option<QualificationProof>,
     ) -> (u64, u32);
     fn add_prize(
         ref self: TState,

--- a/contracts/src/components/tests/libs/store.cairo
+++ b/contracts/src/components/tests/libs/store.cairo
@@ -5,7 +5,7 @@ use dojo::model::{ModelStorage};
 use tournaments::components::models::tournament::{
     Tournament, EntryCount, Prize, Leaderboard, Token, Registration, TournamentConfig,
     TournamentTokenMetrics, PlatformMetrics, PrizeMetrics, PrizeClaim, PrizeType, Metadata,
-    Schedule, GameConfig, EntryConfig,
+    Schedule, GameConfig, EntryFee, EntryRequirement,
 };
 
 use tournaments::components::constants::{VERSION};
@@ -95,11 +95,14 @@ pub impl StoreImpl of StoreTrait {
         metadata: Metadata,
         schedule: Schedule,
         game_config: GameConfig,
-        entry_config: Option<EntryConfig>,
+        entry_fee: Option<EntryFee>,
+        entry_requirement: Option<EntryRequirement>,
     ) -> Tournament {
         let id = self.increment_and_get_tournament_count();
         let creator = starknet::get_caller_address();
-        let tournament = Tournament { id, creator, metadata, schedule, game_config, entry_config };
+        let tournament = Tournament {
+            id, creator, metadata, schedule, game_config, entry_fee, entry_requirement,
+        };
         self.world.write_model(@tournament);
         tournament
     }

--- a/contracts/src/components/tests/mocks/tournament_mock.cairo
+++ b/contracts/src/components/tests/mocks/tournament_mock.cairo
@@ -2,7 +2,7 @@ use starknet::ContractAddress;
 use dojo::world::IWorldDispatcher;
 use tournaments::components::models::tournament::{
     Tournament as TournamentModel, TokenType, Registration, PrizeType, TournamentState, Metadata,
-    Schedule, GameConfig, EntryConfig,
+    Schedule, GameConfig, QualificationProof, EntryFee, EntryRequirement,
 };
 
 #[starknet::interface]
@@ -43,14 +43,15 @@ pub trait ITournamentMock<TState> {
         metadata: Metadata,
         schedule: Schedule,
         game_config: GameConfig,
-        entry_config: Option<EntryConfig>,
+        entry_fee: Option<EntryFee>,
+        entry_requirement: Option<EntryRequirement>,
     ) -> (TournamentModel, u64);
     fn enter_tournament(
         ref self: TState,
         tournament_id: u64,
         player_name: felt252,
         player_address: ContractAddress,
-        qualifying_token_id: Option<u64>,
+        qualification: Option<QualificationProof>,
     ) -> (u64, u32);
     fn submit_score(ref self: TState, tournament_id: u64, token_id: u64, position: u8);
     fn claim_prize(ref self: TState, tournament_id: u64, prize_type: PrizeType);

--- a/contracts/src/presets/tournament.cairo
+++ b/contracts/src/presets/tournament.cairo
@@ -2,7 +2,7 @@ use starknet::ContractAddress;
 use dojo::world::IWorldDispatcher;
 use tournaments::components::models::tournament::{
     Tournament as TournamentModel, TokenType, PrizeType, TournamentState, Metadata, Schedule,
-    GameConfig, EntryConfig,
+    GameConfig, EntryFee, EntryRequirement, QualificationProof,
 };
 
 #[starknet::interface]
@@ -24,14 +24,15 @@ pub trait ITournament<TState> {
         metadata: Metadata,
         schedule: Schedule,
         game_config: GameConfig,
-        entry_config: Option<EntryConfig>,
+        entry_fee: Option<EntryFee>,
+        entry_requirement: Option<EntryRequirement>,
     ) -> (TournamentModel, u64);
     fn enter_tournament(
         ref self: TState,
         tournament_id: u64,
         player_name: felt252,
         player_address: ContractAddress,
-        qualifying_token_id: Option<u256>,
+        qualification: Option<QualificationProof>,
     ) -> (u64, u32);
     fn submit_score(ref self: TState, tournament_id: u64, token_id: u64, position: u8);
     fn claim_prize(ref self: TState, tournament_id: u64, prize_type: PrizeType);


### PR DESCRIPTION
- When entering a tournament with an EntryRequirement, the caller is now required to specify how they are qualifying into the tournament.
- In the case where they are entering a tournament which is gated by winning or participating in a previous set of tournaments, they are required to specify the specific tournament ID and position they finished. This simplifies validation and makes it more gas efficient

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced tournament entry system with more granular control over entry fees and requirements
  - Introduced advanced qualification mechanisms for tournament participation
  - Added support for multiple qualification methods including tournament history and NFT ownership

- **Changes**
  - Replaced single `EntryConfig` with separate `EntryFee` and `EntryRequirement`
  - Updated tournament entry and qualification validation processes
  - Expanded tournament interface to support more complex entry conditions

- **Improvements**
  - More flexible tournament configuration options
  - Improved player qualification verification mechanisms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->