### PR TITLE
increase gas efficiency of submit_score

### DIFF
--- a/contracts/src/components/libs/store.cairo
+++ b/contracts/src/components/libs/store.cairo
@@ -65,7 +65,7 @@ pub impl StoreImpl of StoreTrait {
     }
 
     #[inline(always)]
-    fn get_leaderboard(self: Store, tournament_id: u64) -> Span<u64> {
+    fn get_leaderboard(self: Store, tournament_id: u64) -> Array<u64> {
         let leaderboard: Leaderboard = (self.world.read_model(tournament_id));
         leaderboard.token_ids
     }

--- a/contracts/src/components/models/tournament.cairo
+++ b/contracts/src/components/models/tournament.cairo
@@ -105,7 +105,7 @@ pub struct Registration {
 pub struct Leaderboard {
     #[key]
     pub tournament_id: u64,
-    pub token_ids: Span<u64>,
+    pub token_ids: Array<u64>,
 }
 
 #[dojo::model]

--- a/contracts/src/components/tests/interfaces.cairo
+++ b/contracts/src/components/tests/interfaces.cairo
@@ -145,7 +145,7 @@ pub trait ITournamentMock<TState> {
     fn tournament(self: @TState, tournament_id: u64) -> TournamentModel;
     fn get_registration(self: @TState, tournament_id: u64, token_id: u64) -> Registration;
     fn tournament_entries(self: @TState, tournament_id: u64) -> u64;
-    fn get_leaderboard(self: @TState, tournament_id: u64) -> Span<u64>;
+    fn get_leaderboard(self: @TState, tournament_id: u64) -> Array<u64>;
     fn get_state(self: @TState, tournament_id: u64) -> TournamentState;
     fn is_token_registered(self: @TState, token: ContractAddress) -> bool;
     // TODO: add for V2 (only ERC721 tokens)

--- a/contracts/src/components/tests/mocks/tournament_mock.cairo
+++ b/contracts/src/components/tests/mocks/tournament_mock.cairo
@@ -33,7 +33,7 @@ pub trait ITournamentMock<TState> {
     fn tournament(self: @TState, tournament_id: u64) -> TournamentModel;
     fn get_registration(self: @TState, token_id: u64) -> Registration;
     fn tournament_entries(self: @TState, tournament_id: u64) -> u64;
-    fn get_leaderboard(self: @TState, tournament_id: u64) -> Span<u64>;
+    fn get_leaderboard(self: @TState, tournament_id: u64) -> Array<u64>;
     fn get_state(self: @TState, tournament_id: u64) -> TournamentState;
     fn is_token_registered(self: @TState, token: ContractAddress) -> bool;
     // TODO: add for V2 (only ERC721 tokens)

--- a/contracts/src/components/tests/test_tournament.cairo
+++ b/contracts/src/components/tests/test_tournament.cairo
@@ -1305,16 +1305,16 @@ fn test_submit_score_gas_check() {
     contracts.game.end_game(player10, 10);
 
     // Submit scores for each player
-    contracts.tournament.submit_score(tournament.id, player10, 1);
-    contracts.tournament.submit_score(tournament.id, player9, 1);
-    contracts.tournament.submit_score(tournament.id, player8, 1);
-    contracts.tournament.submit_score(tournament.id, player7, 1);
-    contracts.tournament.submit_score(tournament.id, player6, 1);
-    contracts.tournament.submit_score(tournament.id, player5, 1);
-    contracts.tournament.submit_score(tournament.id, player4, 1);
-    contracts.tournament.submit_score(tournament.id, player3, 1);
-    contracts.tournament.submit_score(tournament.id, player2, 1);
     contracts.tournament.submit_score(tournament.id, player1, 1);
+    contracts.tournament.submit_score(tournament.id, player2, 2);
+    contracts.tournament.submit_score(tournament.id, player3, 3);
+    contracts.tournament.submit_score(tournament.id, player4, 4);
+    contracts.tournament.submit_score(tournament.id, player5, 5);
+    contracts.tournament.submit_score(tournament.id, player6, 6);
+    contracts.tournament.submit_score(tournament.id, player7, 7);
+    contracts.tournament.submit_score(tournament.id, player8, 8);
+    contracts.tournament.submit_score(tournament.id, player9, 9);
+    contracts.tournament.submit_score(tournament.id, player10, 10);
 
     // Roll forward to beyond submission period
     testing::set_block_timestamp(TEST_END_TIME().into() + MIN_SUBMISSION_PERIOD.into() + 1);

--- a/contracts/src/presets/tournament.cairo
+++ b/contracts/src/presets/tournament.cairo
@@ -13,7 +13,7 @@ pub trait ITournament<TState> {
     fn total_tournaments(self: @TState) -> u64;
     fn tournament(self: @TState, tournament_id: u64) -> TournamentModel;
     fn tournament_entries(self: @TState, tournament_id: u64) -> u64;
-    fn get_leaderboard(self: @TState, tournament_id: u64) -> Span<u64>;
+    fn get_leaderboard(self: @TState, tournament_id: u64) -> Array<u64>;
     fn get_state(self: @TState, tournament_id: u64) -> TournamentState;
     fn top_scores(self: @TState, tournament_id: u64) -> Array<u64>;
     fn is_token_registered(self: @TState, token: ContractAddress) -> bool;


### PR DESCRIPTION
* achieves this by switching leaderboard storage from Span to Array and appending to Array when scores are submitted sequentially (1st to last)