### PR TITLE
add created_at timestamp to Tournament model

### DIFF
--- a/contracts/src/components/libs/store.cairo
+++ b/contracts/src/components/libs/store.cairo
@@ -107,8 +107,9 @@ pub impl StoreImpl of StoreTrait {
     ) -> Tournament {
         let id = self.increment_and_get_tournament_count();
         let creator = starknet::get_caller_address();
+        let created_at = starknet::get_block_timestamp();
         let tournament = Tournament {
-            id, creator, metadata, schedule, game_config, entry_fee, entry_requirement,
+            id, creator, created_at, metadata, schedule, game_config, entry_fee, entry_requirement,
         };
         self.world.write_model(@tournament);
         tournament

--- a/contracts/src/components/models/tournament.cairo
+++ b/contracts/src/components/models/tournament.cairo
@@ -8,6 +8,7 @@ use tournaments::components::models::schedule::Schedule;
 pub struct Tournament {
     #[key]
     pub id: u64,
+    pub created_at: u64,
     pub creator: ContractAddress,
     pub metadata: Metadata,
     pub schedule: Schedule,

--- a/contracts/src/components/tests/libs/store.cairo
+++ b/contracts/src/components/tests/libs/store.cairo
@@ -101,8 +101,9 @@ pub impl StoreImpl of StoreTrait {
     ) -> Tournament {
         let id = self.increment_and_get_tournament_count();
         let creator = starknet::get_caller_address();
+        let created_at = starknet::get_block_timestamp();
         let tournament = Tournament {
-            id, creator, metadata, schedule, game_config, entry_fee, entry_requirement,
+            id, creator, created_at, metadata, schedule, game_config, entry_fee, entry_requirement,
         };
         self.world.write_model(@tournament);
         tournament


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Tournaments now automatically capture a creation timestamp when they are initiated, enhancing tracking and record keeping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->