### PR TITLE
add support for game creator tips

### DIFF
--- a/contracts/src/components/constants.cairo
+++ b/contracts/src/components/constants.cairo
@@ -13,6 +13,8 @@ pub const MAX_SUBMISSION_PERIOD: u32 = 604800; // 1 week
 
 pub const SEPOLIA_CHAIN_ID: felt252 = 0x534e5f5345504f4c4941;
 
+pub const GAME_CREATOR_TOKEN_ID: u64 = 0;
+
 pub fn DEFAULT_NS() -> ByteArray {
     "tournaments"
 }

--- a/contracts/src/components/libs/store.cairo
+++ b/contracts/src/components/libs/store.cairo
@@ -99,17 +99,23 @@ pub impl StoreImpl of StoreTrait {
     #[inline(always)]
     fn create_tournament(
         ref self: Store,
+        creator_token_id: u64,
         metadata: Metadata,
         schedule: Schedule,
         game_config: GameConfig,
         entry_fee: Option<EntryFee>,
         entry_requirement: Option<EntryRequirement>,
     ) -> Tournament {
-        let id = self.increment_and_get_tournament_count();
-        let creator = starknet::get_caller_address();
-        let created_at = starknet::get_block_timestamp();
         let tournament = Tournament {
-            id, creator, created_at, metadata, schedule, game_config, entry_fee, entry_requirement,
+            id: self.increment_and_get_tournament_count(),
+            created_at: starknet::get_block_timestamp(),
+            created_by: starknet::get_caller_address(),
+            creator_token_id,
+            metadata,
+            schedule,
+            game_config,
+            entry_fee,
+            entry_requirement,
         };
         self.world.write_model(@tournament);
         tournament

--- a/contracts/src/components/models/tournament.cairo
+++ b/contracts/src/components/models/tournament.cairo
@@ -9,7 +9,8 @@ pub struct Tournament {
     #[key]
     pub id: u64,
     pub created_at: u64,
-    pub creator: ContractAddress,
+    pub created_by: ContractAddress,
+    pub creator_token_id: u64,
     pub metadata: Metadata,
     pub schedule: Schedule,
     pub game_config: GameConfig,

--- a/contracts/src/components/tests/helpers.cairo
+++ b/contracts/src/components/tests/helpers.cairo
@@ -7,7 +7,7 @@ use tournaments::tests::{
     constants::{
         TOURNAMENT_NAME, TOURNAMENT_DESCRIPTION, TEST_REGISTRATION_START_TIME,
         TEST_REGISTRATION_END_TIME, TEST_START_TIME, TEST_END_TIME, SETTINGS_NAME,
-        SETTINGS_DESCRIPTION,
+        SETTINGS_DESCRIPTION, OWNER,
     },
 };
 use tournaments::components::tests::interfaces::{
@@ -105,10 +105,15 @@ pub fn registration_open_beyond_tournament_end() -> Schedule {
 
 pub fn create_basic_tournament(
     tournament: ITournamentMockDispatcher, game: ContractAddress,
-) -> (Tournament, u64) {
+) -> Tournament {
     tournament
         .create_tournament(
-            test_metadata(), test_schedule(), test_game_config(game), Option::None, Option::None,
+            OWNER(),
+            test_metadata(),
+            test_schedule(),
+            test_game_config(game),
+            Option::None,
+            Option::None,
         )
 }
 

--- a/contracts/src/components/tests/interfaces.cairo
+++ b/contracts/src/components/tests/interfaces.cairo
@@ -154,12 +154,13 @@ pub trait ITournamentMock<TState> {
     // fn register_tokens(ref self: TState, tokens: Array<Token>);
     fn create_tournament(
         ref self: TState,
+        creator_rewards_address: ContractAddress,
         metadata: Metadata,
         schedule: Schedule,
         game_config: GameConfig,
         entry_fee: Option<EntryFee>,
         entry_requirement: Option<EntryRequirement>,
-    ) -> (TournamentModel, u64);
+    ) -> TournamentModel;
     fn enter_tournament(
         ref self: TState,
         tournament_id: u64,

--- a/contracts/src/components/tests/libs/store.cairo
+++ b/contracts/src/components/tests/libs/store.cairo
@@ -93,6 +93,7 @@ pub impl StoreImpl of StoreTrait {
     #[inline(always)]
     fn create_tournament(
         ref self: Store,
+        creator_token_id: u64,
         metadata: Metadata,
         schedule: Schedule,
         game_config: GameConfig,
@@ -100,10 +101,18 @@ pub impl StoreImpl of StoreTrait {
         entry_requirement: Option<EntryRequirement>,
     ) -> Tournament {
         let id = self.increment_and_get_tournament_count();
-        let creator = starknet::get_caller_address();
+        let created_by = starknet::get_caller_address();
         let created_at = starknet::get_block_timestamp();
         let tournament = Tournament {
-            id, creator, created_at, metadata, schedule, game_config, entry_fee, entry_requirement,
+            id,
+            creator_token_id,
+            created_by,
+            created_at,
+            metadata,
+            schedule,
+            game_config,
+            entry_fee,
+            entry_requirement,
         };
         self.world.write_model(@tournament);
         tournament

--- a/contracts/src/components/tests/mocks/tournament_mock.cairo
+++ b/contracts/src/components/tests/mocks/tournament_mock.cairo
@@ -37,12 +37,13 @@ pub trait ITournamentMock<TState> {
     // fn register_tokens(ref self: TState, tokens: Array<Token>);
     fn create_tournament(
         ref self: TState,
+        creator_rewards_address: ContractAddress,
         metadata: Metadata,
         schedule: Schedule,
         game_config: GameConfig,
         entry_fee: Option<EntryFee>,
         entry_requirement: Option<EntryRequirement>,
-    ) -> (TournamentModel, u64);
+    ) -> TournamentModel;
     fn enter_tournament(
         ref self: TState,
         tournament_id: u64,

--- a/contracts/src/presets/tournament.cairo
+++ b/contracts/src/presets/tournament.cairo
@@ -22,12 +22,13 @@ pub trait ITournament<TState> {
     // fn register_tokens(ref self: TState, tokens: Array<Token>);
     fn create_tournament(
         ref self: TState,
+        creator_rewards_address: ContractAddress,
         metadata: Metadata,
         schedule: Schedule,
         game_config: GameConfig,
         entry_fee: Option<EntryFee>,
         entry_requirement: Option<EntryRequirement>,
-    ) -> (TournamentModel, u64);
+    ) -> TournamentModel;
     fn enter_tournament(
         ref self: TState,
         tournament_id: u64,


### PR DESCRIPTION
The Game Component initializer takes in a `creator_address` and mints token ID 0 to that address.
The Tournament contract (and all other meta apps) can then easily issue rewards to the game creator by sending them to the owner of token ID 0 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Tournament creation now integrates a dedicated creator token identifier, ensuring improved tracking of tournament ownership and reward attribution.
	- The registration process has been streamlined to enhance efficiency and clarity.
  
- **Refactor**
	- Updated tournament ownership fields for clearer representation of the creator, providing a more intuitive tournament management experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->