### PR TITLE
add opus cash to pre-registered tokens

### DIFF
--- a/contracts/src/presets/tournament.cairo
+++ b/contracts/src/presets/tournament.cairo
@@ -184,5 +184,14 @@ pub mod Budokan {
                 "Beasts",
                 "BEASTS",
             );
+        self
+            .tournament
+            .initialize_erc20(
+                contract_address_const::<
+                    0x498edfaf50ca5855666a700c25dd629d577eb9afccdf3b5977aec79aee55ada,
+                >(),
+                "Cash",
+                "CASH",
+            );
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced token registration during tournament setup, adding support for a new ERC20 token ("Cash", symbol "CASH") to enhance token management capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->