### PR TITLE
only perform entry limit if limit is above zero

### DIFF
--- a/contracts/src/components/tournament.cairo
+++ b/contracts/src/components/tournament.cairo
@@ -1595,10 +1595,14 @@ pub mod tournament_component {
                         store, tournament_id, entry_requirement, player_address, qualifier,
                     );
 
-                self
-                    ._update_qualification_entries(
-                        ref store, tournament_id, qualifier, entry_requirement.entry_limit,
-                    );
+                // if entry limit was specified
+                if entry_requirement.entry_limit != 0 {
+                    // check and update limit requirements
+                    self
+                        ._update_qualification_entries(
+                            ref store, tournament_id, qualifier, entry_requirement.entry_limit,
+                        );
+                }
             } else {
                 panic!(
                     "Tournament: Tournament {} has an entry requirement but no qualification was provided",

--- a/contracts/src/presets/tournament.cairo
+++ b/contracts/src/presets/tournament.cairo
@@ -61,9 +61,7 @@ pub trait ITournament<TState> {
 pub mod Budokan {
     use starknet::{contract_address_const};
     use tournaments::components::tournament::tournament_component;
-    use tournaments::components::constants::{
-        MAINNET_CHAIN_ID,
-    };
+    use tournaments::components::constants::{MAINNET_CHAIN_ID};
 
     component!(path: tournament_component, storage: tournament, event: TournamentEvent);
     #[abi(embed_v0)]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved tournament qualification handling so that updates occur only when a valid tournament entry limit is defined, preventing unnecessary or incorrect updates.
- **Style**
	- Simplified import statements in the `Budokan` module for better readability without impacting functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->