### PR TITLE
upgrade from dojo 1.3.0 to 1.4.0

### DIFF
--- a/.github/workflows/test-contract.yml
+++ b/.github/workflows/test-contract.yml
@@ -1,8 +1,8 @@
 name: test-contracts
 
 env:
-  SCARB_VERSION: 2.9.2
-  DOJO_VERSION: 1.3.0
+  SCARB_VERSION: 2.9.4
+  DOJO_VERSION: 1.4.0
 
 on:
   pull_request:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-dojo 1.3.0
-scarb 2.9.2
+dojo 1.4.0
+scarb 2.9.4

--- a/contracts/Scarb.lock
+++ b/contracts/Scarb.lock
@@ -3,8 +3,8 @@ version = 1
 
 [[package]]
 name = "dojo"
-version = "1.3.0"
-source = "git+https://github.com/dojoengine/dojo.git?tag=v1.3.0#e4702479ec9cf0f01d6927d36f0a3910cf6cb3e3"
+version = "1.4.0"
+source = "git+https://github.com/dojoengine/dojo.git?tag=v1.4.0#22ef7101e84429f4f06fa634f927dd6ad2c48752"
 dependencies = [
  "dojo_plugin",
 ]
@@ -12,28 +12,29 @@ dependencies = [
 [[package]]
 name = "dojo_cairo_test"
 version = "1.0.12"
-source = "git+https://github.com/dojoengine/dojo.git?tag=v1.3.0#e4702479ec9cf0f01d6927d36f0a3910cf6cb3e3"
+source = "git+https://github.com/dojoengine/dojo.git?tag=v1.4.0#22ef7101e84429f4f06fa634f927dd6ad2c48752"
 dependencies = [
  "dojo",
 ]
 
 [[package]]
 name = "dojo_plugin"
-version = "2.9.2"
-source = "git+https://github.com/dojoengine/dojo.git?tag=v1.3.0#e4702479ec9cf0f01d6927d36f0a3910cf6cb3e3"
+version = "2.9.4"
+source = "git+https://github.com/dojoengine/dojo.git?tag=v1.4.0#22ef7101e84429f4f06fa634f927dd6ad2c48752"
 
 [[package]]
 name = "openzeppelin_access"
-version = "0.20.0"
-source = "git+https://github.com/openzeppelin/cairo-contracts?tag=v0.20.0#7756fd1de2b4ebd239fa6e372d75535cea02e5e5"
+version = "1.0.0"
+source = "git+https://github.com/openzeppelin/cairo-contracts?tag=v1.0.0#755ce1adbf8d89ed23fbb8daa328fcbeab7c6424"
 dependencies = [
  "openzeppelin_introspection",
+ "openzeppelin_utils",
 ]
 
 [[package]]
 name = "openzeppelin_account"
-version = "0.20.0"
-source = "git+https://github.com/openzeppelin/cairo-contracts?tag=v0.20.0#7756fd1de2b4ebd239fa6e372d75535cea02e5e5"
+version = "1.0.0"
+source = "git+https://github.com/openzeppelin/cairo-contracts?tag=v1.0.0#755ce1adbf8d89ed23fbb8daa328fcbeab7c6424"
 dependencies = [
  "openzeppelin_introspection",
  "openzeppelin_utils",
@@ -41,13 +42,13 @@ dependencies = [
 
 [[package]]
 name = "openzeppelin_introspection"
-version = "0.20.0"
-source = "git+https://github.com/openzeppelin/cairo-contracts?tag=v0.20.0#7756fd1de2b4ebd239fa6e372d75535cea02e5e5"
+version = "1.0.0"
+source = "git+https://github.com/openzeppelin/cairo-contracts?tag=v1.0.0#755ce1adbf8d89ed23fbb8daa328fcbeab7c6424"
 
 [[package]]
 name = "openzeppelin_token"
-version = "0.20.0"
-source = "git+https://github.com/openzeppelin/cairo-contracts?tag=v0.20.0#7756fd1de2b4ebd239fa6e372d75535cea02e5e5"
+version = "1.0.0"
+source = "git+https://github.com/openzeppelin/cairo-contracts?tag=v1.0.0#755ce1adbf8d89ed23fbb8daa328fcbeab7c6424"
 dependencies = [
  "openzeppelin_access",
  "openzeppelin_account",
@@ -57,8 +58,8 @@ dependencies = [
 
 [[package]]
 name = "openzeppelin_utils"
-version = "0.20.0"
-source = "git+https://github.com/openzeppelin/cairo-contracts?tag=v0.20.0#7756fd1de2b4ebd239fa6e372d75535cea02e5e5"
+version = "1.0.0"
+source = "git+https://github.com/openzeppelin/cairo-contracts?tag=v1.0.0#755ce1adbf8d89ed23fbb8daa328fcbeab7c6424"
 
 [[package]]
 name = "tournaments"

--- a/contracts/Scarb.toml
+++ b/contracts/Scarb.toml
@@ -1,5 +1,5 @@
 [package]
-cairo-version = "=2.9.2"
+cairo-version = "=2.9.4"
 name = "tournaments"
 version = "0.0.1"
 edition = "2024_07"
@@ -11,14 +11,14 @@ sierra = true
 build-external-contracts = ["dojo::world::world_contract::world"]
 
 [dependencies]
-openzeppelin_introspection = { git = "https://github.com/openzeppelin/cairo-contracts", tag = "v0.20.0"}
-openzeppelin_token = { git = "https://github.com/openzeppelin/cairo-contracts", tag = "v0.20.0"}
-dojo = { git = "https://github.com/dojoengine/dojo.git", tag = "v1.3.0" }
-starknet = "2.9.2"
+openzeppelin_introspection = { git = "https://github.com/openzeppelin/cairo-contracts", tag = "v1.0.0"}
+openzeppelin_token = { git = "https://github.com/openzeppelin/cairo-contracts", tag = "v1.0.0"}
+dojo = { git = "https://github.com/dojoengine/dojo.git", tag = "v1.4.0" }
+starknet = "2.9.4"
 
 [dev-dependencies]
-dojo_cairo_test = { git = "https://github.com/dojoengine/dojo.git", tag = "v1.3.0" }
-cairo_test = "2.9.2"
+dojo_cairo_test = { git = "https://github.com/dojoengine/dojo.git", tag = "v1.4.0" }
+cairo_test = "2.9.4"
 
 [features]
 default = []


### PR DESCRIPTION
- scarb 2.9.2 to 2.9.4
- open zeppelin 0.20.0 to 1.0.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated versions of development tools and dependencies to the latest releases, including upgrades for dojo, scarb, and related libraries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->