### PR TITLE
change internal Registration model

### DIFF
--- a/contracts/src/components/libs/store.cairo
+++ b/contracts/src/components/libs/store.cairo
@@ -60,8 +60,8 @@ pub impl StoreImpl of StoreTrait {
     }
 
     #[inline(always)]
-    fn get_registration(self: Store, tournament_id: u64, token_id: u64) -> Registration {
-        (self.world.read_model((tournament_id, token_id)))
+    fn get_registration(self: Store, game_address: ContractAddress, token_id: u64) -> Registration {
+        (self.world.read_model((game_address, token_id)))
     }
 
     #[inline(always)]

--- a/contracts/src/components/models/tournament.cairo
+++ b/contracts/src/components/models/tournament.cairo
@@ -89,9 +89,10 @@ pub enum TokenType {
 #[derive(Copy, Drop, Serde, IntrospectPacked)]
 pub struct Registration {
     #[key]
-    pub tournament_id: u64,
+    pub game_address: ContractAddress,
     #[key]
     pub game_token_id: u64,
+    pub tournament_id: u64,
     pub entry_number: u32,
     pub has_submitted: bool,
 }

--- a/contracts/src/components/tests/interfaces.cairo
+++ b/contracts/src/components/tests/interfaces.cairo
@@ -145,7 +145,9 @@ pub trait ITournamentMock<TState> {
     // ITournament
     fn total_tournaments(self: @TState) -> u64;
     fn tournament(self: @TState, tournament_id: u64) -> TournamentModel;
-    fn get_registration(self: @TState, tournament_id: u64, token_id: u64) -> Registration;
+    fn get_registration(
+        self: @TState, game_address: ContractAddress, token_id: u64,
+    ) -> Registration;
     fn get_prize(self: @TState, prize_id: u64) -> Prize;
     fn tournament_entries(self: @TState, tournament_id: u64) -> u64;
     fn get_leaderboard(self: @TState, tournament_id: u64) -> Array<u64>;

--- a/contracts/src/components/tests/libs/store.cairo
+++ b/contracts/src/components/tests/libs/store.cairo
@@ -55,8 +55,8 @@ pub impl StoreImpl of StoreTrait {
     }
 
     #[inline(always)]
-    fn get_registration(self: Store, tournament_id: u64, token_id: u64) -> Registration {
-        (self.world.read_model((tournament_id, token_id)))
+    fn get_registration(self: Store, game_address: ContractAddress, token_id: u64) -> Registration {
+        (self.world.read_model((game_address, token_id)))
     }
 
     #[inline(always)]

--- a/contracts/src/components/tests/mocks/tournament_mock.cairo
+++ b/contracts/src/components/tests/mocks/tournament_mock.cairo
@@ -28,7 +28,9 @@ pub trait ITournamentMock<TState> {
     // ITournament
     fn total_tournaments(self: @TState) -> u64;
     fn tournament(self: @TState, tournament_id: u64) -> TournamentModel;
-    fn get_registration(self: @TState, token_id: u64) -> Registration;
+    fn get_registration(
+        self: @TState, game_address: ContractAddress, token_id: u64,
+    ) -> Registration;
     fn get_prize(self: @TState, prize_id: u64) -> Prize;
     fn tournament_entries(self: @TState, tournament_id: u64) -> u64;
     fn get_leaderboard(self: @TState, tournament_id: u64) -> Array<u64>;

--- a/contracts/src/components/tests/test_tournament.cairo
+++ b/contracts/src/components/tests/test_tournament.cairo
@@ -1184,18 +1184,8 @@ fn enter_tournament() {
 
     let tournament = create_basic_tournament(contracts.tournament, contracts.game.contract_address);
 
-    // assert the returned creator game token id has the correct registration information
-    let token = contracts.tournament.get_registration(tournament.id, tournament.creator_token_id);
-    assert!(
-        token.tournament_id == tournament.id,
-        "Wrong tournament id, expected: {}, got: {}",
-        tournament.id,
-        token.tournament_id,
-    );
-    assert!(token.entry_number == 0, "Entry number should be 0");
-    assert!(token.has_submitted == false, "submitted score should be false");
-
-    // assert we own the minted game token for the creator
+    // assert a token was minted to the tournament creator (used for claiming tournament host
+    // rewards)
     assert!(
         contracts.game.owner_of(tournament.creator_token_id.into()) == OWNER(),
         "Wrong ownership for creator game token",
@@ -1215,7 +1205,9 @@ fn enter_tournament() {
     );
 
     // verify registration information
-    let player1_registration = contracts.tournament.get_registration(tournament.id, game_token_id);
+    let player1_registration = contracts
+        .tournament
+        .get_registration(contracts.game.contract_address, game_token_id);
 
     assert!(
         player1_registration.tournament_id == tournament.id,
@@ -2892,9 +2884,9 @@ fn test_submit_score_tie_higher_game_id_for_lower_position() {
     assert!(*leaderboard.at(2) == token_id3, "Invalid third place");
 
     // Verify registrations are marked as submitted
-    let reg1 = contracts.tournament.get_registration(tournament.id, token_id1);
-    let reg2 = contracts.tournament.get_registration(tournament.id, token_id2);
-    let reg3 = contracts.tournament.get_registration(tournament.id, token_id3);
+    let reg1 = contracts.tournament.get_registration(contracts.game.contract_address, token_id1);
+    let reg2 = contracts.tournament.get_registration(contracts.game.contract_address, token_id2);
+    let reg3 = contracts.tournament.get_registration(contracts.game.contract_address, token_id3);
 
     assert!(reg1.has_submitted, "Player 1 should be marked as submitted");
     assert!(reg2.has_submitted, "Player 2 should be marked as submitted");


### PR DESCRIPTION
- previous model was flawed in that it didn't provide opportunity to lookup tournament_id from a game_id

@starknetdev fyi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a method to retrieve the tournament ID for a given game address and token ID.

- **Refactor**
  - Updated registration lookup and related methods to use the game contract address and token ID, instead of the tournament ID and token ID.
  - Modified the Registration data structure to use the game address as a key field.
  - Adjusted test cases and interface methods to reflect these changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->